### PR TITLE
Enrich OSV results with grype data

### DIFF
--- a/scanners/grype/grype.go
+++ b/scanners/grype/grype.go
@@ -41,15 +41,39 @@ type Match struct {
 
 // Vulnerability is the primary matched vulnerability record.
 type Vulnerability struct {
-	ID          string   `json:"id"`
-	DataSource  string   `json:"dataSource"`
-	Namespace   string   `json:"namespace"`
-	Severity    string   `json:"severity"`
-	URLs        []string `json:"urls"`
-	Description string   `json:"description"`
-	CVSS        []CVSS   `json:"cvss"`
-	Fix         Fix      `json:"fix"`
-	Risk        float64  `json:"risk"`
+	ID             string           `json:"id"`
+	DataSource     string           `json:"dataSource"`
+	Namespace      string           `json:"namespace"`
+	Severity       string           `json:"severity"`
+	URLs           []string         `json:"urls"`
+	Description    string           `json:"description"`
+	CVSS           []CVSS           `json:"cvss"`
+	Fix            Fix              `json:"fix"`
+	Risk           float64          `json:"risk"`
+	EPSS           []EPSSScore      `json:"epss"`
+	KnownExploited []KnownExploited `json:"knownExploited"`
+	CWEs           []CWE            `json:"cwes"`
+}
+
+// EPSSScore is a single EPSS record for a vulnerability. EPSS holds the exploit
+// prediction probability (0..1) and Percentile its ranking among all scores.
+type EPSSScore struct {
+	CVE        string  `json:"cve"`
+	EPSS       float64 `json:"epss"`
+	Percentile float64 `json:"percentile"`
+}
+
+// KnownExploited flags a vulnerability as listed in a known-exploited catalog
+// (e.g. CISA KEV). Only its presence is consumed, so the entry is minimal.
+type KnownExploited struct {
+	CVE string `json:"cve"`
+}
+
+// CWE is a single weakness classification attached to a vulnerability. CWE
+// carries the identifier string (e.g. "CWE-426").
+type CWE struct {
+	CVE string `json:"cve"`
+	CWE string `json:"cwe"`
 }
 
 // RelatedVulnerability is an alias or closely related record (e.g. the CVE
@@ -266,6 +290,30 @@ func databaseSpecific(vuln *Vulnerability) (*structpb.Struct, error) {
 	}
 	if len(scores) > 0 {
 		fields["cvss_scores"] = scores
+	}
+
+	// Exploitability enrichment consumed by downstream policies. epss is always
+	// emitted (0 when grype supplied no score) so policies can rely on the key.
+	epss := 0.0
+	if len(vuln.EPSS) > 0 {
+		epss = vuln.EPSS[0].EPSS
+	}
+	fields["epss"] = epss
+
+	if len(vuln.KnownExploited) > 0 {
+		fields["known_exploited"] = true
+	}
+
+	if len(vuln.CWEs) > 0 {
+		cweIDs := make([]any, 0, len(vuln.CWEs))
+		for _, cwe := range vuln.CWEs {
+			if cwe.CWE != "" {
+				cweIDs = append(cweIDs, cwe.CWE)
+			}
+		}
+		if len(cweIDs) > 0 {
+			fields["cwe_ids"] = cweIDs
+		}
 	}
 
 	if len(fields) == 0 {

--- a/scanners/grype/grype_test.go
+++ b/scanners/grype/grype_test.go
@@ -68,6 +68,49 @@ func TestToOSV(t *testing.T) {
 	require.Equal(t, "fixed", db["fix_state"])
 	require.Contains(t, db, "risk")
 	require.Contains(t, db, "cvss_scores")
+
+	// EPSS enrichment: the probability from the first EPSS record.
+	epss, ok := db["epss"].(float64)
+	require.True(t, ok, "epss should be a float64")
+	require.Greater(t, epss, 0.0)
+
+	// CWE enrichment: cwe_ids is populated from the second match's cwes list.
+	cweRecord := findRecord(results, "GHSA-hfvc-g4fc-pqhx")
+	require.NotNil(t, cweRecord, "expected GHSA-hfvc-g4fc-pqhx in the converted results")
+	require.Contains(t, cweRecord.GetDatabaseSpecific().AsMap()["cwe_ids"], "CWE-426")
+}
+
+func TestDatabaseSpecificEnrichment(t *testing.T) {
+	t.Parallel()
+
+	// knownExploited is absent from the committed testdata, so exercise all the
+	// enrichment fields together with a synthetic document.
+	doc := &Document{
+		Matches: []Match{{
+			Vulnerability: Vulnerability{
+				ID:             "CVE-2026-0001",
+				EPSS:           []EPSSScore{{CVE: "CVE-2026-0001", EPSS: 0.42, Percentile: 0.9}},
+				KnownExploited: []KnownExploited{{CVE: "CVE-2026-0001"}},
+				CWEs: []CWE{
+					{CVE: "CVE-2026-0001", CWE: "CWE-79"},
+					{CVE: "CVE-2026-0001", CWE: "CWE-89"},
+				},
+			},
+			Artifact: Artifact{Name: "acme", Version: "1.0.0"},
+		}},
+	}
+
+	results, err := doc.ToOSV()
+	require.NoError(t, err)
+
+	record := findRecord(results, "CVE-2026-0001")
+	require.NotNil(t, record)
+
+	db := record.GetDatabaseSpecific().AsMap()
+	require.Equal(t, true, db["known_exploited"])
+	require.InDelta(t, 0.42, db["epss"], 1e-9)
+	require.Contains(t, db["cwe_ids"], "CWE-79")
+	require.Contains(t, db["cwe_ids"], "CWE-89")
 }
 
 func TestToOSVDeterministic(t *testing.T) {


### PR DESCRIPTION
This pull request adds new vulnerability enrichment fields to the Grype scanner, improving the amount and quality of vulnerability metadata available for downstream consumers and policies. The main changes include support for EPSS scores, known exploited status, and CWE identifiers, along with corresponding test coverage.

**Vulnerability data enrichment:**

* Added `EPSSScore`, `KnownExploited`, and `CWE` types to the `Vulnerability` struct in `grype.go`, enabling the scanner to capture exploit prediction scores, known exploitation status, and weakness classifications for vulnerabilities.
* Updated the `databaseSpecific` function to emit new fields: `epss` (exploit prediction score), `known_exploited` (boolean flag), and `cwe_ids` (list of CWE identifiers) in the output, making these enrichments available for policy checks and consumers.

**Test coverage:**

* Enhanced `TestToOSV` to assert the presence and correctness of the new enrichment fields in converted vulnerability results.
* Added a new test, `TestDatabaseSpecificEnrichment`, to verify that all enrichment fields (`epss`, `known_exploited`, and `cwe_ids`) are correctly populated and exported for synthetic vulnerability records.